### PR TITLE
Add fieldTagNames for GeoDoubleParams metadata

### DIFF
--- a/src/globals.js
+++ b/src/globals.js
@@ -163,6 +163,7 @@ export const fieldTagTypes = {
   34264: 'DOUBLE',
   34665: 'LONG',
   34735: 'SHORT',
+  34736: 'DOUBLE',
   34737: 'ASCII',
   42113: 'ASCII',
 };


### PR DESCRIPTION
Fixes https://github.com/geotiffjs/geotiff.js/issues/384